### PR TITLE
fixed Promise syntax in openPR function

### DIFF
--- a/pages/api/openPR.js
+++ b/pages/api/openPR.js
@@ -249,38 +249,36 @@ export default async (req, res) => {
         parseProjectName(values),
         getSubmissionFiles(values, nomineeJSON)
       )
-    ).then((results) => {
-      let pullRequestNumbers = [];
+    );
+    let pullRequestNumbers = [];
 
-      // Only returning successful results in an array of PR number(s)
-      results.forEach(async (result) => {
-        if (result.status == "fulfilled") {
-          pullRequestNumbers.push(result.value.data.number);
+    // Only returning successful results in an array of PR number(s)
+    result.forEach(async (result) => {
+      if (result.status == "fulfilled") {
+        pullRequestNumbers.push(result.value.data.number);
+        console.log("printing pull request numbers");
 
-          if (GITHUB_ASSIGNEES) {
-            await octokit.request(
-              "DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees",
-              {
-                owner: GITHUB_OWNER,
-                repo: GITHUB_REPO,
-                issue_number: result.value.data.number,
-                assignees: ["dpgabot"],
-              }
-            );
-            await octokit.request(
-              "POST /repos/{owner}/{repo}/issues/{issue_number}/assignees",
-              {
-                owner: GITHUB_OWNER,
-                repo: GITHUB_REPO,
-                issue_number: result.value.data.number,
-                assignees: GITHUB_ASSIGNEES,
-              }
-            );
-          }
+        if (GITHUB_ASSIGNEES) {
+          await octokit.request(
+            "DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees",
+            {
+              owner: GITHUB_OWNER,
+              repo: GITHUB_REPO,
+              issue_number: result.value.data.number,
+              assignees: ["dpgabot"],
+            }
+          );
+          await octokit.request(
+            "POST /repos/{owner}/{repo}/issues/{issue_number}/assignees",
+            {
+              owner: GITHUB_OWNER,
+              repo: GITHUB_REPO,
+              issue_number: result.value.data.number,
+              assignees: GITHUB_ASSIGNEES,
+            }
+          );
         }
-      });
-
-      return pullRequestNumbers;
+      }
     });
 
     // return an unconditional success response

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -139,7 +139,7 @@ const schema = {
               },
               fields: [
                 {
-                  name: "repositories.name",
+                  name: "name",
                   component: "text-field",
                   label: "Repository name",
                   helperText: "For example: main, frontend, backend etc.",
@@ -151,7 +151,7 @@ const schema = {
                   ],
                 },
                 {
-                  name: "repositories.url",
+                  name: "url",
                   component: "text-field",
                   label: "Link to Github (or other) repository",
                   description:


### PR DESCRIPTION
This PR fixes #99 

Corrected some syntax in the function that creates a pull request which was returning an empty array.
This empty array triggers the error page even though the submission and the PR have been made.

@lacabra I noticed this on the PR. It seems mine failed with this error

```
[
  {
    status: 'rejected',
    reason: RequestError [HttpError]: Validation Failed: {"resource":"PullRequest","field":"head","code":"invalid"}
        at /Users/nathanfletcher/Documents/DEVELOPER/unicef/submission-digitalpublicgoods/node_modules/@octokit/request/dist-node/index.js:86:21
        at runMicrotasks (<anonymous>)
        at processTicksAndRejections (node:internal/process/task_queues:96:5)
        at async composeCreatePullRequest (/Users/nathanfletcher/Documents/DEVELOPER/unicef/submission-digitalpublicgoods/node_modules/octokit-plugin-create-pull-request/dist-node/index.js:290:10) {
      status: 422,
      response: [Object],
      request: [Object]
    }
  }
]
```

It is not blocking the submission, however, I'll address it in another PR so that this can be pushed to make the form work again.