### PR TITLE
BUG: fix repositories, handle errors

### DIFF
--- a/pages/error.js
+++ b/pages/error.js
@@ -31,6 +31,7 @@ function Error() {
   const classes = useStyles();
   const router = useRouter();
   const [values, setValues] = useState({});
+  const [error, setError] = useState({});
   const [cookies] = useCookies(["uuid"]);
 
   useEffect(() => {
@@ -40,6 +41,7 @@ function Error() {
       setValues(values);
     }
     fetchData();
+    setError(JSON.parse(router.query.error));
   }, []);
 
   return (
@@ -59,7 +61,7 @@ function Error() {
           and include the information below:
         </p>
         <h3 style={{alignSelf: "flex-start"}}>Error:</h3>
-        <pre style={{alignSelf: "flex-start"}}>{router.query.error}</pre>
+        <pre style={{alignSelf: "flex-start"}}>{JSON.stringify(error, null, 2)}</pre>
 
         <h3 style={{alignSelf: "flex-start"}}>Copy of your submission:</h3>
         <pre style={{alignSelf: "flex-start"}}>{JSON.stringify(values, null, 2)}</pre>

--- a/pages/form.js
+++ b/pages/form.js
@@ -158,10 +158,10 @@ export default function Home() {
     // Save contact information to google spreadsheet
     saveContactToGoogleSpreadsheet(values);
 
-    if (result.length == 0) {
+    if (response.status != 200) {
       router.push({
         pathname: "/error",
-        query: {error: result.error},
+        query: {error: JSON.stringify(result)},
         state: values,
       });
     } else {

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -139,7 +139,7 @@ const schema = {
               },
               fields: [
                 {
-                  name: "repositories.name",
+                  name: "name",
                   component: "text-field",
                   label: "Repository name",
                   helperText: "For example: main, frontend, backend etc.",
@@ -151,7 +151,7 @@ const schema = {
                   ],
                 },
                 {
-                  name: "repositories.url",
+                  name: "url",
                   component: "text-field",
                   label: "Link to Github (or other) repository",
                   description:

--- a/scripts/validate-schema.js
+++ b/scripts/validate-schema.js
@@ -153,6 +153,12 @@ function removeFields(obj) {
   } else {
     throw "SPDX or licenseURL fields missing";
   }
+  if (Object.prototype.hasOwnProperty.call(obj, "url")) {
+    obj["repositories"] = {name: {}, url: obj["url"]};
+    delete obj["url"];
+  } else {
+    throw "repositories is missing url field";
+  }
   obj["SDGs"] = {SDGNumber: {}, evidenceText: {}, evidenceURL: {}};
   return obj;
 }


### PR DESCRIPTION
Superseeds #100:
- amends the submission schema in the same way as proposed in #100
- patches the parsing of `repositories` where extra `[` and `]` have been removed. The object is already an array.
- patches the schema validator to account for the new structure of `repositories` much like `licenses` is handled
- refactors the `api/openPR` to properly handle errors that result from octokit's call to openPR, and propagates that change through `form.js` and `error.js` to properly display any errors.


The proof of this fix can be seen in DPGAlliance/publicgoods-candidates#943 and the CI passing.