### PR TITLE
Update Support Email Id

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -65,7 +65,7 @@ export default function Intro() {
           <p>
             Problems?{" "}
             <a href="mailto:support@digitalpublicgoods.net">
-              nominations@digitalpublicgoods.net
+              support@digitalpublicgoods.net
             </a>
           </p>
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -64,7 +64,7 @@ export default function Intro() {
 
           <p>
             Problems?{" "}
-            <a href="mailto:nominations@digitalpublicgoods.net">
+            <a href="mailto:support@digitalpublicgoods.net">
               nominations@digitalpublicgoods.net
             </a>
           </p>

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -266,7 +266,7 @@ const schema = {
                 },
               ],
               description:
-                "DPGs must use an open license. Please identify which of these approved open licenses this project uses: *. For Open-Source Software, we only accept OSI approved licenses. For Open Content we require the use of a Creative Commons license while we encourage projects to use a license which allows for both derivatives and commercial reuse or dedicate content to the public domain (CC0) we also accept licenses which do not allow for commercial reuse: CC-BY-NC and CC-BY-NC-SA. For data we require a Open Data Commons approved license listed at opendefinition.org/licenses/. IF YOU USE A LICENSE THAT IS NOT CURRENTLY LISTED HERE BUT YOU BELIEVE SHOULD BE INCLUDED PLEASE EMAIL nominations@digitalpublicgoods.net",
+                "DPGs must use an open license. Please identify which of these approved open licenses this project uses: *. For Open-Source Software, we only accept OSI approved licenses. For Open Content we require the use of a Creative Commons license while we encourage projects to use a license which allows for both derivatives and commercial reuse or dedicate content to the public domain (CC0) we also accept licenses which do not allow for commercial reuse: CC-BY-NC and CC-BY-NC-SA. For data we require a Open Data Commons approved license listed at opendefinition.org/licenses/. IF YOU USE A LICENSE THAT IS NOT CURRENTLY LISTED HERE BUT YOU BELIEVE SHOULD BE INCLUDED PLEASE EMAIL support@digitalpublicgoods.net",
               RemoveButtonGridProps: {xs: 3},
               FieldGroupGridProps: {xs: 9},
               fields: [


### PR DESCRIPTION
Emails to nominations@digitalpublicgoods.net have stopped since we have moved away from google groups and setup gsuite email ids. This pull request replaces nominations@digitalpublicgoods.net with support@digitalpublicgoods.net on the submission form first page - which handles reporting of issues.