### PR TITLE
[UPGRADE]: Remove Option For Partial Submissions

### DIFF
--- a/pages/api/openPR.js
+++ b/pages/api/openPR.js
@@ -97,10 +97,11 @@ function getSubmissionFiles(values, nomineeJSON) {
   let name,
     nomineePath,
     dpgPath,
-    stage,
+    //stage,  // remove stage from fields since its not captured anymore
     data,
     files = {};
-  stage = values.stage;
+  //stage = values.stage;
+  let stage = "DPG";
   // Delete multiple DPG nomination fields
   [
     "aliases",
@@ -110,7 +111,7 @@ function getSubmissionFiles(values, nomineeJSON) {
     "SDGs",
     "license",
     "organizations",
-    "stage",
+    //"stage",
     "repositories",
   ].forEach((e) => delete values[e]);
   // Convert JavaScript submission sorted object into JSON string and add newline at EOF

--- a/pages/api/openPR.js
+++ b/pages/api/openPR.js
@@ -111,7 +111,7 @@ function getSubmissionFiles(values, nomineeJSON) {
     "SDGs",
     "license",
     "organizations",
-    //"stage",
+    "stage",
     "repositories",
   ].forEach((e) => delete values[e]);
   // Convert JavaScript submission sorted object into JSON string and add newline at EOF

--- a/pages/api/openPR.js
+++ b/pages/api/openPR.js
@@ -100,8 +100,7 @@ function getSubmissionFiles(values, nomineeJSON) {
     stage,
     data,
     files = {};
-  //stage = values.stage;
-  stage = "DPG";
+  stage = values.stage = "DPG";
   // Delete multiple DPG nomination fields
   [
     "aliases",

--- a/pages/api/openPR.js
+++ b/pages/api/openPR.js
@@ -97,11 +97,11 @@ function getSubmissionFiles(values, nomineeJSON) {
   let name,
     nomineePath,
     dpgPath,
-    //stage,  // remove stage from fields since its not captured anymore
+    stage,
     data,
     files = {};
   //stage = values.stage;
-  let stage = "DPG";
+  stage = "DPG";
   // Delete multiple DPG nomination fields
   [
     "aliases",

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -10,13 +10,14 @@ const schema = {
         {
           title: "Get started with submission wizard form",
           name: "step-1",
-          nextStep: {
+          /* nextStep: {
             when: "stage",
             stepMapper: {
               nominee: "nominee-final-step",
               DPG: "clearOwnership",
             },
-          },
+          }, */
+          nextStep: "clearOwnership",
           fields: [
             {
               name: "name",
@@ -914,7 +915,7 @@ const schema = {
                 },
               ],
             },
-            {
+            /*    {
               component: "radio",
               name: "stage",
               label: "What would you like to do?",
@@ -935,7 +936,7 @@ const schema = {
                   type: "required",
                 },
               ],
-            },
+            }, */
           ],
         },
         {

--- a/scripts/validate-schema.js
+++ b/scripts/validate-schema.js
@@ -223,6 +223,9 @@ fetch(NOMINEE_SCHEMA)
         // The submission form is missing the sectors, delete
         delete refSchema.sectors;
 
+        // The submission form is missing the stage, delete
+        delete refSchema.stage;
+
         // Process the submission schema, to match the ref. schema
         const wizard = getSubmissionKeys(schema.schema["fields"][0]);
         let submissionSchema = flattenObject(wizard["wizard"]);


### PR DESCRIPTION
This PR eilimates from the submission form the option to make a partial submission currently possible by selecting "Submit now as a DPG Nominee".

**Observations:**
- [x] Form behaviour not interrupted, still works properly.
- [ ] 1 validation test [failing](https://github.com/dpgabot/submission-digitalpublicgoods/blob/main/scripts/validate-schema.js#L188). Console log dispalys - `stage field is missing from form`. **Rationale:**This is expected since stage field is now obsolete in the form, but still used for the schema comparison and also in the [nominee-schema.json](https://github.com/DPGAlliance/publicgoods-candidates/blob/main/nominee-schema.json), so I would regard this as a `WARNING` and not `ERROR`.
